### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A proof of concept integration between Claude Desktop and Neovim using Model Context Protocol (MCP) and the official neovim/node-client JavaScript library. This demo leverages Vim's native text editing commands and workflows, which Claude already understands, to create a lightweight code assistance layer.
 
+<a href="https://glama.ai/mcp/servers/s0fywdwp87"><img width="380" height="200" src="https://glama.ai/mcp/servers/s0fywdwp87/badge" alt="mcp-neovim-server MCP server" /></a>
+
 ## Features
 
 - Connects to your nvim instance if you expose `--listen /tmp/nvim` when starting nvim


### PR DESCRIPTION
This PR adds a badge for the mcp-neovim-server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/s0fywdwp87"><img width="380" height="200" src="https://glama.ai/mcp/servers/s0fywdwp87/badge" alt="mcp-neovim-server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.