### PR TITLE
feat: Add claude.zsh wrapper for Neovim MCP

### DIFF
--- a/scripts/claude.zsh
+++ b/scripts/claude.zsh
@@ -1,0 +1,39 @@
+#!/usr/bin/env zsh
+# Claude wrapper that adds Neovim MCP server when inside Neovim
+
+# Run claude normally if $NVIM is not set
+if [[ -z "$NVIM" ]]; then
+  command claude "$@"
+  return
+fi
+
+# If $NVIM is set, create a temporary MCP config
+local tmp_config=$(mktemp /tmp/claude-mcp."${NVIM:t}".XXX.json)
+
+# Write the MCP config with the Neovim server
+cat >"$tmp_config" <<EOF
+{
+"mcpServers": {
+  "nvim": {
+    "command": "npx",
+    "args": [
+      "-y",
+      "mcp-neovim-server"
+    ],
+    "env": {
+      "ALLOW_SHELL_COMMANDS": "true",
+      "NVIM_SOCKET_PATH": "$NVIM"
+    }
+  }
+}
+}
+EOF
+
+# Run claude with the custom config
+command claude --mcp-config "$tmp_config" "$@"
+local exit_code=$?
+
+# Clean up
+rm -f "$tmp_config"
+
+return $exit_code


### PR DESCRIPTION
Here is a wrapper script I use for connecting to the parent `nvim` process' RPC server with `mcp-neovim-server` when `claude` is started in a child process of `nvim`.

Feel free to do what you wish with this PR. I'm not expecting this to be accepted as is. I just wanted to share, so let me know if you have any questions.